### PR TITLE
hotfix on type-conversion of percentage columns

### DIFF
--- a/R/ipc_get.R
+++ b/R/ipc_get.R
@@ -62,11 +62,28 @@ ipc_get <- function(
       )
     }
 
-    purrr::map_dfr(
+    ipc_list_df <- purrr::map(
       .x = ipc_list,
-      .f = ~ null_converter(.x, drop_metadata = drop_metadata)
-        %>% dplyr::as_tibble()
+      .f = ~ null_converter(.x, drop_metadata = drop_metadata) %>%
+        dplyr::as_tibble()
     )
+
+    ipc_list_df %>%
+      purrr::map(
+        \(dft){
+          dft %>%
+            dplyr::mutate(
+              dplyr::across(
+                dplyr::matches(
+                  "_percentage$"
+                ),
+                ~as.numeric(.x)
+              )
+            )
+        }
+      ) %>%
+      purrr::list_rbind() %>%
+      dplyr::as_tibble()
 }
 
 #' Get IPC API key


### PR DESCRIPTION
Temporary hotfix to deal w/ improper type conversion from `{ripc}`. 

Some `_percentage` columns reading as "character" some reading as "numeric". Issue outlined here:

https://github.com/OCHA-DAP/ripc/issues/7#issue-2154372435

I posed a few potential ideas for more robust fix's there, but have done a quick fix here to deal with the _percentage columns only to minimize any side-effects.


